### PR TITLE
slim down metrics

### DIFF
--- a/manifests/valence/prometheus/config-map.yaml
+++ b/manifests/valence/prometheus/config-map.yaml
@@ -22,6 +22,10 @@ data:
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       tls_config:
         insecure_skip_verify: true
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(kube_pod_container_resource_requests_memory_bytes|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests_cpu_cores|kube_pod_container_resource_limits_cpu_cores|kube_deployment_status_replicas_available)
+        action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_app]
         separator: ;
@@ -88,6 +92,10 @@ data:
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         insecure_skip_verify: true
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(container_memory_working_set_bytes|container_cpu_usage_seconds_total)
+        action: keep
       relabel_configs:
       - separator: ;
         regex: __meta_kubernetes_node_label_(.+)
@@ -111,6 +119,10 @@ data:
       scheme: http
       kubernetes_sd_configs:
       - role: endpoints
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(promproxy_metric_handler_detailed_requests_count|promproxy_metric_handler_detailed_requests)
+        action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_valence_net_prometheus]
         separator: ;
@@ -167,6 +179,10 @@ data:
         namespaces:
           names:
           - valence-system
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(valence_recommendations_memory_requests|valence_recommendations_memory_limits|valence_recommendations_cpu_requests|valence_recommendations_cpu_limits|valence_recommendations_replicas)
+        action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
         separator: ;

--- a/manifests/valence/prometheus/config-map.yaml
+++ b/manifests/valence/prometheus/config-map.yaml
@@ -11,7 +11,7 @@ data:
     rule_files:
       - "/etc/prometheus-rules/*.rules"
     scrape_configs:
-    - job_name: kube-state-metrics/0
+    - job_name: kube-state-metrics
       honor_labels: true
       scrape_interval: 1m
       scrape_timeout: 10s
@@ -73,101 +73,6 @@ data:
         regex: (.*)
         target_label: endpoint
         replacement: metrics
-        action: replace
-    - job_name: kube-state-metrics/1
-      scrape_interval: 1m
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      scheme: http
-      kubernetes_sd_configs:
-      - role: endpoints
-        namespaces:
-          names:
-          - valence-system
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tls_config:
-        insecure_skip_verify: true
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_service_label_app]
-        separator: ;
-        regex: kube-state-metrics
-        replacement: $1
-        action: keep
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
-        separator: ;
-        regex: telemetry
-        replacement: $1
-        action: keep
-      - source_labels: [__meta_kubernetes_namespace]
-        separator: ;
-        regex: (.*)
-        target_label: namespace
-        replacement: $1
-        action: replace
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
-        target_label: node
-        replacement: ${1}
-        action: replace
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Pod;(.*)
-        target_label: pod
-        replacement: ${1}
-        action: replace
-      - source_labels: [__meta_kubernetes_service_name]
-        separator: ;
-        regex: (.*)
-        target_label: service
-        replacement: $1
-        action: replace
-      - source_labels: [__meta_kubernetes_service_name]
-        separator: ;
-        regex: (.*)
-        target_label: job
-        replacement: ${1}
-        action: replace
-      - source_labels: [__meta_kubernetes_service_label_app]
-        separator: ;
-        regex: (.+)
-        target_label: job
-        replacement: ${1}
-        action: replace
-      - separator: ;
-        regex: (.*)
-        target_label: endpoint
-        replacement: telemetry
-        action: replace
-    - job_name: kubernetes-nodes
-      scrape_interval: 1m
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      scheme: https
-      kubernetes_sd_configs:
-      - api_server: null
-        role: node
-        namespaces:
-          names: []
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        insecure_skip_verify: true
-      relabel_configs:
-      - separator: ;
-        regex: __meta_kubernetes_node_label_(.+)
-        replacement: $1
-        action: labelmap
-      - separator: ;
-        regex: (.*)
-        target_label: __address__
-        replacement: kubernetes.default.svc:443
-        action: replace
-      - source_labels: [__meta_kubernetes_node_name]
-        separator: ;
-        regex: (.+)
-        target_label: __metrics_path__
-        replacement: /api/v1/nodes/${1}/proxy/metrics
         action: replace
     - job_name: kubernetes-nodes-cadvisor
       scrape_interval: 1m

--- a/valence.yaml
+++ b/valence.yaml
@@ -860,6 +860,10 @@ data:
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       tls_config:
         insecure_skip_verify: true
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(kube_pod_container_resource_requests_memory_bytes|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests_cpu_cores|kube_pod_container_resource_limits_cpu_cores|kube_deployment_status_replicas_available)
+        action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_app]
         separator: ;
@@ -926,6 +930,10 @@ data:
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         insecure_skip_verify: true
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(container_memory_working_set_bytes|container_cpu_usage_seconds_total)
+        action: keep
       relabel_configs:
       - separator: ;
         regex: __meta_kubernetes_node_label_(.+)
@@ -949,6 +957,10 @@ data:
       scheme: http
       kubernetes_sd_configs:
       - role: endpoints
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(promproxy_metric_handler_detailed_requests_count|promproxy_metric_handler_detailed_requests)
+        action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_valence_net_prometheus]
         separator: ;
@@ -1005,6 +1017,10 @@ data:
         namespaces:
           names:
           - valence-system
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: (?i)(valence_recommendations_memory_requests|valence_recommendations_memory_limits|valence_recommendations_cpu_requests|valence_recommendations_cpu_limits|valence_recommendations_replicas)
+        action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
         separator: ;

--- a/valence.yaml
+++ b/valence.yaml
@@ -849,7 +849,7 @@ data:
     rule_files:
       - "/etc/prometheus-rules/*.rules"
     scrape_configs:
-    - job_name: kube-state-metrics/0
+    - job_name: kube-state-metrics
       honor_labels: true
       scrape_interval: 1m
       scrape_timeout: 10s
@@ -911,101 +911,6 @@ data:
         regex: (.*)
         target_label: endpoint
         replacement: metrics
-        action: replace
-    - job_name: kube-state-metrics/1
-      scrape_interval: 1m
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      scheme: http
-      kubernetes_sd_configs:
-      - role: endpoints
-        namespaces:
-          names:
-          - valence-system
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tls_config:
-        insecure_skip_verify: true
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_service_label_app]
-        separator: ;
-        regex: kube-state-metrics
-        replacement: $1
-        action: keep
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
-        separator: ;
-        regex: telemetry
-        replacement: $1
-        action: keep
-      - source_labels: [__meta_kubernetes_namespace]
-        separator: ;
-        regex: (.*)
-        target_label: namespace
-        replacement: $1
-        action: replace
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Node;(.*)
-        target_label: node
-        replacement: ${1}
-        action: replace
-      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-        separator: ;
-        regex: Pod;(.*)
-        target_label: pod
-        replacement: ${1}
-        action: replace
-      - source_labels: [__meta_kubernetes_service_name]
-        separator: ;
-        regex: (.*)
-        target_label: service
-        replacement: $1
-        action: replace
-      - source_labels: [__meta_kubernetes_service_name]
-        separator: ;
-        regex: (.*)
-        target_label: job
-        replacement: ${1}
-        action: replace
-      - source_labels: [__meta_kubernetes_service_label_app]
-        separator: ;
-        regex: (.+)
-        target_label: job
-        replacement: ${1}
-        action: replace
-      - separator: ;
-        regex: (.*)
-        target_label: endpoint
-        replacement: telemetry
-        action: replace
-    - job_name: kubernetes-nodes
-      scrape_interval: 1m
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      scheme: https
-      kubernetes_sd_configs:
-      - api_server: null
-        role: node
-        namespaces:
-          names: []
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        insecure_skip_verify: true
-      relabel_configs:
-      - separator: ;
-        regex: __meta_kubernetes_node_label_(.+)
-        replacement: $1
-        action: labelmap
-      - separator: ;
-        regex: (.*)
-        target_label: __address__
-        replacement: kubernetes.default.svc:443
-        action: replace
-      - source_labels: [__meta_kubernetes_node_name]
-        separator: ;
-        regex: (.+)
-        target_label: __metrics_path__
-        replacement: /api/v1/nodes/${1}/proxy/metrics
         action: replace
     - job_name: kubernetes-nodes-cadvisor
       scrape_interval: 1m


### PR DESCRIPTION
Slims down metrics so that less metrics are being used by prometheus.
Here we only take a whitelist of relevant metrics to reduce the in-cluster footprint of Valence.
Those metrics right now are:
```
container_memory_working_set_bytes - kubernetes-nodes-cadvisor

valence_recommendations_memory_requests - optimization-operator
valence_recommendations_memory_limits

kube_pod_container_resource_requests_memory_bytes - kube-state-metrics
kube_pod_container_resource_limits_memory_bytes

container_cpu_usage_seconds_total

valence_recommendations_cpu_requests
valence_recommendations_cpu_limits

kube_pod_container_resource_requests_cpu_cores
kube_pod_container_resource_limits_cpu_cores

promproxy_metric_handler_detailed_requests_count
promproxy_metric_handler_detailed_requests

valence_recommendations_replicas

kube_deployment_status_replicas_available
```