### PR TITLE
add original metrics and SLOs for better reporting

### DIFF
--- a/manifests/valence/prometheus/config-map.yaml
+++ b/manifests/valence/prometheus/config-map.yaml
@@ -181,7 +181,7 @@ data:
           - valence-system
       metric_relabel_configs:
       - source_labels: [__name__]
-        regex: (?i)(valence_recommendations_memory_requests|valence_recommendations_memory_limits|valence_recommendations_cpu_requests|valence_recommendations_cpu_limits|valence_recommendations_replicas)
+        regex: (?i)(valence_recommendations_memory_requests|valence_recommendations_memory_limits|valence_recommendations_cpu_requests|valence_recommendations_cpu_limits|valence_recommendations_replicas|valence_original_cpu_limits|valence_original_cpu_requests|valence_original_memory_limits|valence_original_memory_requests|valence_original_replicas|valence_slo_http_latency|valence_slo_http_percentile|valence_slo_http_throughput)
         action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]

--- a/valence.yaml
+++ b/valence.yaml
@@ -1019,7 +1019,7 @@ data:
           - valence-system
       metric_relabel_configs:
       - source_labels: [__name__]
-        regex: (?i)(valence_recommendations_memory_requests|valence_recommendations_memory_limits|valence_recommendations_cpu_requests|valence_recommendations_cpu_limits|valence_recommendations_replicas)
+        regex: (?i)(valence_recommendations_memory_requests|valence_recommendations_memory_limits|valence_recommendations_cpu_requests|valence_recommendations_cpu_limits|valence_recommendations_replicas|valence_original_cpu_limits|valence_original_cpu_requests|valence_original_memory_limits|valence_original_memory_requests|valence_original_replicas|valence_slo_http_latency|valence_slo_http_percentile|valence_slo_http_throughput)
         action: keep
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]


### PR DESCRIPTION
We want to provide the original settings set by the operator and the declared SLOs as metrics in order to improve reporting and recommendations experience.